### PR TITLE
✨ feat: add normalized Sankey flow on dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
 		"react-dom": "^19.0.0",
 		"react-hook-form": "^7.54.2",
 		"react-icons": "^5.5.0",
+		"recharts": "^3.8.0",
 		"sonner": "^2.0.1",
 		"tailwind-merge": "^3.0.2",
 		"tailwindcss-animate": "^1.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,9 @@ importers:
       react-icons:
         specifier: ^5.5.0
         version: 5.5.0(react@19.0.0)
+      recharts:
+        specifier: ^3.8.0
+        version: 3.8.0(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react-is@16.13.1)(react@19.0.0)(redux@5.0.1)
       sonner:
         specifier: ^2.0.1
         version: 2.0.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -2216,6 +2219,20 @@ packages:
         integrity: sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg==,
       }
 
+  '@reduxjs/toolkit@2.11.2':
+    resolution:
+      {
+        integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==,
+      }
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
   '@rtsao/scc@1.1.0':
     resolution:
       {
@@ -2234,6 +2251,12 @@ packages:
         integrity: sha512-1hsLpRHfSuMB9ee2aAdh0Htza/X3f4djhYISrggqGe3xopNjOcePiSDkDDoPzDYaaMCrbqGP1H2TYU7bgL9PmA==,
       }
     engines: { node: '>=20.0.0' }
+
+  '@standard-schema/spec@1.1.0':
+    resolution:
+      {
+        integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==,
+      }
 
   '@standard-schema/utils@0.3.0':
     resolution:
@@ -2276,6 +2299,60 @@ packages:
     resolution:
       {
         integrity: sha512-fnQmj8lELIj7BSrZQAdBMHEHX8OZLYIHXqAKT1O7tDfLxaINzf00PMjw22r3N/xXh0w/sGHlO6SVaCQ2mj78lg==,
+      }
+
+  '@types/d3-array@3.2.2':
+    resolution:
+      {
+        integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==,
+      }
+
+  '@types/d3-color@3.1.3':
+    resolution:
+      {
+        integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==,
+      }
+
+  '@types/d3-ease@3.0.2':
+    resolution:
+      {
+        integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==,
+      }
+
+  '@types/d3-interpolate@3.0.4':
+    resolution:
+      {
+        integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==,
+      }
+
+  '@types/d3-path@3.1.1':
+    resolution:
+      {
+        integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==,
+      }
+
+  '@types/d3-scale@4.0.9':
+    resolution:
+      {
+        integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==,
+      }
+
+  '@types/d3-shape@3.1.8':
+    resolution:
+      {
+        integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==,
+      }
+
+  '@types/d3-time@3.0.4':
+    resolution:
+      {
+        integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==,
+      }
+
+  '@types/d3-timer@3.0.2':
+    resolution:
+      {
+        integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==,
       }
 
   '@types/estree@1.0.6':
@@ -2326,6 +2403,12 @@ packages:
     resolution:
       {
         integrity: sha512-JuRQ9KXLEjaUNjTWpzuR231Z2WpIwczOkBEIvbHNCzQefFIT0L8IqE6NV6ULLyC1SI/i234JnDoMkfg+RjQj2g==,
+      }
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution:
+      {
+        integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==,
       }
 
   '@typescript-eslint/eslint-plugin@8.57.1':
@@ -3041,6 +3124,83 @@ packages:
         integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==,
       }
 
+  d3-array@3.2.4:
+    resolution:
+      {
+        integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==,
+      }
+    engines: { node: '>=12' }
+
+  d3-color@3.1.0:
+    resolution:
+      {
+        integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==,
+      }
+    engines: { node: '>=12' }
+
+  d3-ease@3.0.1:
+    resolution:
+      {
+        integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==,
+      }
+    engines: { node: '>=12' }
+
+  d3-format@3.1.2:
+    resolution:
+      {
+        integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==,
+      }
+    engines: { node: '>=12' }
+
+  d3-interpolate@3.0.1:
+    resolution:
+      {
+        integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==,
+      }
+    engines: { node: '>=12' }
+
+  d3-path@3.1.0:
+    resolution:
+      {
+        integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==,
+      }
+    engines: { node: '>=12' }
+
+  d3-scale@4.0.2:
+    resolution:
+      {
+        integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==,
+      }
+    engines: { node: '>=12' }
+
+  d3-shape@3.2.0:
+    resolution:
+      {
+        integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==,
+      }
+    engines: { node: '>=12' }
+
+  d3-time-format@4.1.0:
+    resolution:
+      {
+        integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==,
+      }
+    engines: { node: '>=12' }
+
+  d3-time@3.1.0:
+    resolution:
+      {
+        integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==,
+      }
+    engines: { node: '>=12' }
+
+  d3-timer@3.0.1:
+    resolution:
+      {
+        integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==,
+      }
+    engines: { node: '>=12' }
+
   damerau-levenshtein@1.0.8:
     resolution:
       {
@@ -3108,6 +3268,12 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js-light@2.5.1:
+    resolution:
+      {
+        integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==,
+      }
 
   decompress-response@6.0.0:
     resolution:
@@ -3390,6 +3556,12 @@ packages:
       }
     engines: { node: '>= 0.4' }
 
+  es-toolkit@1.45.1:
+    resolution:
+      {
+        integrity: sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==,
+      }
+
   esbuild-register@3.6.0:
     resolution:
       {
@@ -3609,6 +3781,12 @@ packages:
         integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==,
       }
     engines: { node: '>=0.10.0' }
+
+  eventemitter3@5.0.4:
+    resolution:
+      {
+        integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==,
+      }
 
   execa@5.1.1:
     resolution:
@@ -3971,6 +4149,18 @@ packages:
       }
     engines: { node: '>= 4' }
 
+  immer@10.2.0:
+    resolution:
+      {
+        integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==,
+      }
+
+  immer@11.1.4:
+    resolution:
+      {
+        integrity: sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==,
+      }
+
   import-fresh@3.3.1:
     resolution:
       {
@@ -4003,6 +4193,13 @@ packages:
         integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==,
       }
     engines: { node: '>= 0.4' }
+
+  internmap@2.0.3:
+    resolution:
+      {
+        integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==,
+      }
+    engines: { node: '>=12' }
 
   is-array-buffer@3.0.5:
     resolution:
@@ -5157,6 +5354,21 @@ packages:
         integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==,
       }
 
+  react-redux@9.2.0:
+    resolution:
+      {
+        integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==,
+      }
+    peerDependencies:
+      '@types/react': ^18.2.25 || ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
+
   react-remove-scroll-bar@2.3.8:
     resolution:
       {
@@ -5223,6 +5435,31 @@ packages:
       }
     engines: { node: '>=8.10.0' }
 
+  recharts@3.8.0:
+    resolution:
+      {
+        integrity: sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ==,
+      }
+    engines: { node: '>=18' }
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  redux-thunk@3.1.0:
+    resolution:
+      {
+        integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==,
+      }
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution:
+      {
+        integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==,
+      }
+
   reflect.getprototypeof@1.0.10:
     resolution:
       {
@@ -5236,6 +5473,12 @@ packages:
         integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==,
       }
     engines: { node: '>= 0.4' }
+
+  reselect@5.1.1:
+    resolution:
+      {
+        integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==,
+      }
 
   resolve-from@4.0.0:
     resolution:
@@ -5674,6 +5917,12 @@ packages:
         integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==,
       }
 
+  tiny-invariant@1.3.3:
+    resolution:
+      {
+        integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==,
+      }
+
   tinyglobby@0.2.15:
     resolution:
       {
@@ -5854,6 +6103,14 @@ packages:
       '@types/react':
         optional: true
 
+  use-sync-external-store@1.6.0:
+    resolution:
+      {
+        integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==,
+      }
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   util-deprecate@1.0.2:
     resolution:
       {
@@ -5870,6 +6127,12 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  victory-vendor@37.3.6:
+    resolution:
+      {
+        integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==,
+      }
 
   which-boxed-primitive@1.1.1:
     resolution:
@@ -7133,6 +7396,18 @@ snapshots:
 
   '@radix-ui/rect@1.1.0': {}
 
+  '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.0.10)(react@19.0.0)(redux@5.0.1))(react@19.0.0)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.4
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.1.1
+    optionalDependencies:
+      react: 19.0.0
+      react-redux: 9.2.0(@types/react@19.0.10)(react@19.0.0)(redux@5.0.1)
+
   '@rtsao/scc@1.1.0': {}
 
   '@simplewebauthn/browser@13.1.0': {}
@@ -7146,6 +7421,8 @@ snapshots:
       '@peculiar/asn1-rsa': 2.3.15
       '@peculiar/asn1-schema': 2.3.15
       '@peculiar/asn1-x509': 2.3.15
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@standard-schema/utils@0.3.0': {}
 
@@ -7175,6 +7452,30 @@ snapshots:
       '@types/node': 20.19.37
     optional: true
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/estree@1.0.6': {}
 
   '@types/json-schema@7.0.15': {}
@@ -7203,6 +7504,8 @@ snapshots:
   '@types/react@19.0.10':
     dependencies:
       csstype: 3.1.3
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@typescript-eslint/eslint-plugin@8.57.1(@typescript-eslint/parser@8.57.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)':
     dependencies:
@@ -7646,6 +7949,44 @@ snapshots:
 
   csstype@3.1.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   damerau-levenshtein@1.0.8: {}
 
   data-view-buffer@1.0.2:
@@ -7679,6 +8020,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js-light@2.5.1: {}
 
   decompress-response@6.0.0:
     dependencies:
@@ -7867,6 +8210,8 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  es-toolkit@1.45.1: {}
 
   esbuild-register@3.6.0(esbuild@0.19.12):
     dependencies:
@@ -8163,6 +8508,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  eventemitter3@5.0.4: {}
+
   execa@5.1.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -8369,6 +8716,10 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  immer@10.2.0: {}
+
+  immer@11.1.4: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -8387,6 +8738,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  internmap@2.0.3: {}
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -8994,6 +9347,15 @@ snapshots:
 
   react-is@16.13.1: {}
 
+  react-redux@9.2.0(@types/react@19.0.10)(react@19.0.0)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 19.0.0
+      use-sync-external-store: 1.6.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.10
+      redux: 5.0.1
+
   react-remove-scroll-bar@2.3.8(@types/react@19.0.10)(react@19.0.0):
     dependencies:
       react: 19.0.0
@@ -9038,6 +9400,32 @@ snapshots:
     dependencies:
       picomatch: 2.3.1
 
+  recharts@3.8.0(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react-is@16.13.1)(react@19.0.0)(redux@5.0.1):
+    dependencies:
+      '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.0.10)(react@19.0.0)(redux@5.0.1))(react@19.0.0)
+      clsx: 2.1.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.45.1
+      eventemitter3: 5.0.4
+      immer: 10.2.0
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+      react-is: 16.13.1
+      react-redux: 9.2.0(@types/react@19.0.10)(react@19.0.0)(redux@5.0.1)
+      reselect: 5.1.1
+      tiny-invariant: 1.3.3
+      use-sync-external-store: 1.6.0(react@19.0.0)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
+
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
+
   reflect.getprototypeof@1.0.10:
     dependencies:
       call-bind: 1.0.8
@@ -9057,6 +9445,8 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  reselect@5.1.1: {}
 
   resolve-from@4.0.0: {}
 
@@ -9409,6 +9799,8 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  tiny-invariant@1.3.3: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
@@ -9558,11 +9950,32 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.0.10
 
+  use-sync-external-store@1.6.0(react@19.0.0):
+    dependencies:
+      react: 19.0.0
+
   util-deprecate@1.0.2: {}
 
   valibot@1.0.0-rc.3(typescript@5.7.3):
     optionalDependencies:
       typescript: 5.7.3
+
+  victory-vendor@37.3.6:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   which-boxed-primitive@1.1.1:
     dependencies:

--- a/src/app/dashboard/_components/application-process-sankey-chart.tsx
+++ b/src/app/dashboard/_components/application-process-sankey-chart.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { useMemo } from 'react';
+import { Sankey, Tooltip } from 'recharts';
+import type { SankeyNodeProps } from 'recharts/types';
+
+import { ChartContainer, type ChartConfig } from '~/components/ui/chart';
+
+type SankeyNode = { name: string };
+type SankeyLink = { source: number; target: number; value: number };
+
+const stageColorMap: Record<string, string> = {
+	Apply: 'hsl(var(--chart-1))',
+	OA: 'hsl(var(--chart-2))',
+	Interview: 'hsl(var(--chart-4))',
+	Offer: 'hsl(142 76% 36%)',
+	Rejected: 'hsl(var(--destructive))',
+	Ghosted: 'hsl(263 70% 50%)',
+};
+
+const chartConfig = Object.fromEntries(
+	Object.entries(stageColorMap).map(([stage, color]) => [
+		stage,
+		{ label: stage, color },
+	]),
+) satisfies ChartConfig;
+
+type ApplicationProcessSankeyChartProps = {
+	nodes: SankeyNode[];
+	links: SankeyLink[];
+};
+
+type SankeyNodeWithCount = SankeyNode & { count: number };
+
+const CustomSankeyNode = (props: SankeyNodeProps) => {
+	const { x, y, width, height, payload } = props;
+	const name = String(payload.name ?? '');
+	const nodeCount = Number(payload.value ?? 0);
+	const fill =
+		stageColorMap[name] ??
+		(name.startsWith('Interview #')
+			? stageColorMap.Interview
+			: 'hsl(var(--primary))');
+	const label = `${name} (${nodeCount})`;
+
+	const showLabelOnRight = Number(x) < 500;
+	const labelX = showLabelOnRight ? x + width + 8 : x - 8;
+	const textAnchor = showLabelOnRight ? 'start' : 'end';
+
+	return (
+		<g>
+			<rect
+				x={x}
+				y={y}
+				width={width}
+				height={height}
+				fill={fill}
+				fillOpacity={0.9}
+				stroke="hsl(var(--border))"
+				strokeWidth={1}
+			/>
+			<text
+				x={labelX}
+				y={y + height / 2}
+				dy="0.35em"
+				textAnchor={textAnchor}
+				fontSize={12}
+				fill="hsl(var(--foreground))"
+			>
+				{label}
+			</text>
+		</g>
+	);
+};
+
+export const ApplicationProcessSankeyChart = ({
+	nodes,
+	links,
+}: ApplicationProcessSankeyChartProps) => {
+	const nodesWithCount = useMemo<SankeyNodeWithCount[]>(() => {
+		const incoming = Array.from({ length: nodes.length }, () => 0);
+		const outgoing = Array.from({ length: nodes.length }, () => 0);
+
+		for (const link of links) {
+			outgoing[link.source] += link.value;
+			incoming[link.target] += link.value;
+		}
+
+		return nodes.map((node, index) => ({
+			...node,
+			count: Math.max(incoming[index], outgoing[index]),
+		}));
+	}, [links, nodes]);
+
+	if (links.length === 0) {
+		return (
+			<div className="flex h-full items-center justify-center text-muted-foreground">
+				No completed outcomes yet. Add Offer, Rejected, or Ghosted applications.
+			</div>
+		);
+	}
+
+	return (
+		<ChartContainer config={chartConfig} className="h-full w-full">
+			<Sankey
+				data={{ nodes: nodesWithCount, links }}
+				margin={{ top: 12, right: 12, bottom: 12, left: 12 }}
+				nodePadding={24}
+				nodeWidth={16}
+				linkCurvature={0.5}
+				iterations={64}
+				node={CustomSankeyNode}
+				link={{
+					stroke: 'hsl(var(--muted-foreground))',
+					strokeOpacity: 0.35,
+				}}
+			>
+				<Tooltip />
+			</Sankey>
+		</ChartContainer>
+	);
+};

--- a/src/app/dashboard/_components/application-process-sankey-chart.tsx
+++ b/src/app/dashboard/_components/application-process-sankey-chart.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo } from 'react';
 import { Sankey, Tooltip } from 'recharts';
-import type { SankeyNodeProps } from 'recharts/types';
+import type { SankeyLinkProps, SankeyNodeProps } from 'recharts/types';
 
 import { ChartContainer, type ChartConfig } from '~/components/ui/chart';
 
@@ -77,6 +77,33 @@ const CustomSankeyNode = (props: SankeyNodeProps) => {
 	);
 };
 
+const CustomSankeyLink = (props: SankeyLinkProps) => {
+	const {
+		payload,
+		sourceX,
+		targetX,
+		sourceY,
+		targetY,
+		sourceControlX,
+		targetControlX,
+		linkWidth,
+	} = props;
+	const targetName = String(payload?.target?.name ?? '');
+	const isToHiddenOngoingNode = targetName === 'Ongoing';
+	const pathD = `M${sourceX},${sourceY}
+		C${sourceControlX},${sourceY} ${targetControlX},${targetY} ${targetX},${targetY}`;
+
+	return (
+		<path
+			d={pathD}
+			stroke={isToHiddenOngoingNode ? 'transparent' : 'hsl(var(--muted-foreground))'}
+			strokeOpacity={isToHiddenOngoingNode ? 0 : 0.35}
+			fill="none"
+			strokeWidth={linkWidth}
+		/>
+	);
+};
+
 export const ApplicationProcessSankeyChart = ({
 	nodes,
 	links,
@@ -114,10 +141,7 @@ export const ApplicationProcessSankeyChart = ({
 				linkCurvature={0.5}
 				iterations={64}
 				node={CustomSankeyNode}
-				link={{
-					stroke: 'hsl(var(--muted-foreground))',
-					strokeOpacity: 0.35,
-				}}
+				link={CustomSankeyLink}
 			>
 				<Tooltip />
 			</Sankey>

--- a/src/app/dashboard/_components/application-process-sankey-chart.tsx
+++ b/src/app/dashboard/_components/application-process-sankey-chart.tsx
@@ -13,6 +13,7 @@ const stageColorMap: Record<string, string> = {
 	Apply: 'hsl(var(--chart-1))',
 	OA: 'hsl(var(--chart-2))',
 	Interview: 'hsl(var(--chart-4))',
+	Ongoing: 'hsl(var(--chart-3))',
 	Offer: 'hsl(142 76% 36%)',
 	Rejected: 'hsl(var(--destructive))',
 	Ghosted: 'hsl(263 70% 50%)',
@@ -95,7 +96,7 @@ export const ApplicationProcessSankeyChart = ({
 	if (links.length === 0) {
 		return (
 			<div className="flex h-full items-center justify-center text-muted-foreground">
-				No completed outcomes yet. Add Offer, Rejected, or Ghosted applications.
+				No process transitions yet.
 			</div>
 		);
 	}

--- a/src/app/dashboard/_components/application-process-sankey-chart.tsx
+++ b/src/app/dashboard/_components/application-process-sankey-chart.tsx
@@ -37,6 +37,7 @@ const CustomSankeyNode = (props: SankeyNodeProps) => {
 	const { x, y, width, height, payload } = props;
 	const name = String(payload.name ?? '');
 	const nodeCount = Number(payload.value ?? 0);
+	const isHiddenOngoingNode = name === 'Ongoing';
 	const fill =
 		stageColorMap[name] ??
 		(name.startsWith('Interview #')
@@ -55,21 +56,23 @@ const CustomSankeyNode = (props: SankeyNodeProps) => {
 				y={y}
 				width={width}
 				height={height}
-				fill={fill}
-				fillOpacity={0.9}
-				stroke="hsl(var(--border))"
-				strokeWidth={1}
+				fill={isHiddenOngoingNode ? 'transparent' : fill}
+				fillOpacity={isHiddenOngoingNode ? 0 : 0.9}
+				stroke={isHiddenOngoingNode ? 'transparent' : 'hsl(var(--border))'}
+				strokeWidth={isHiddenOngoingNode ? 0 : 1}
 			/>
-			<text
-				x={labelX}
-				y={y + height / 2}
-				dy="0.35em"
-				textAnchor={textAnchor}
-				fontSize={12}
-				fill="hsl(var(--foreground))"
-			>
-				{label}
-			</text>
+			{!isHiddenOngoingNode && (
+				<text
+					x={labelX}
+					y={y + height / 2}
+					dy="0.35em"
+					textAnchor={textAnchor}
+					fontSize={12}
+					fill="hsl(var(--foreground))"
+				>
+					{label}
+				</text>
+			)}
 		</g>
 	);
 };

--- a/src/app/dashboard/_data/application-process-sankey.ts
+++ b/src/app/dashboard/_data/application-process-sankey.ts
@@ -1,0 +1,127 @@
+import { db } from '~/db';
+
+type SankeyStage =
+	| 'Apply'
+	| 'OA'
+	| `Interview #${number}`
+	| 'Offer'
+	| 'Rejected'
+	| 'Ghosted';
+const TERMINAL_OUTCOMES = new Set(['Offer', 'Rejected', 'Ghosted']);
+
+export type SankeyNode = { name: SankeyStage };
+export type SankeyLink = { source: number; target: number; value: number };
+export type SankeyData = { nodes: SankeyNode[]; links: SankeyLink[] };
+
+const stageRank = (stage: SankeyStage): number => {
+	if (stage === 'Apply') return 0;
+	if (stage === 'OA') return 1;
+	if (stage.startsWith('Interview #')) {
+		const interviewNumber = Number(stage.replace('Interview #', ''));
+		return 2 + interviewNumber;
+	}
+	if (stage === 'Offer') return 100;
+	if (stage === 'Ghosted') return 101;
+	if (stage === 'Rejected') return 102;
+	return Number.MAX_SAFE_INTEGER;
+};
+
+const buildApplicationPath = (
+	interviewTypes: string[],
+	finalStatus: string,
+): SankeyStage[] => {
+	const orderedInterviews = interviewTypes;
+
+	const stages: SankeyStage[] = ['Apply'];
+	let hasOA = false;
+	let interviewRound = 0;
+
+	for (const interviewType of orderedInterviews) {
+		if (interviewType === 'OA' && !hasOA) {
+			stages.push('OA');
+			hasOA = true;
+			continue;
+		}
+		interviewRound += 1;
+		stages.push(`Interview #${interviewRound}`);
+	}
+
+	if (
+		(finalStatus === 'Offer' ||
+			finalStatus === 'Rejected' ||
+			finalStatus === 'Ghosted') &&
+		stages[stages.length - 1] !== finalStatus
+	) {
+		stages.push(finalStatus);
+	}
+
+	return stages;
+};
+
+export const getApplicationProcessSankeyData = async (
+	userId: string,
+): Promise<SankeyData> => {
+	const applications = await db.query.applicationsTable.findMany({
+		where: (applications, { eq }) => eq(applications.userId, userId),
+		with: {
+			interviews: {
+				orderBy: (interviews, { asc }) => asc(interviews.date),
+			},
+		},
+	});
+	const edgeWeights = new Map<string, number>();
+
+	for (const application of applications) {
+		if (!TERMINAL_OUTCOMES.has(application.status)) {
+			continue;
+		}
+		const interviews = application.interviews.map((interview) =>
+			String(interview.type),
+		);
+		const path = buildApplicationPath(interviews, application.status);
+
+		for (let index = 0; index < path.length - 1; index += 1) {
+			const source = path[index];
+			const target = path[index + 1];
+			const edgeKey = `${source}->${target}`;
+			edgeWeights.set(edgeKey, (edgeWeights.get(edgeKey) ?? 0) + 1);
+		}
+	}
+
+	const nodeNames = new Set<SankeyStage>();
+	for (const edgeKey of edgeWeights.keys()) {
+		const [source, target] = edgeKey.split('->') as [SankeyStage, SankeyStage];
+		nodeNames.add(source);
+		nodeNames.add(target);
+	}
+
+	if (nodeNames.size === 0) {
+		return { nodes: [], links: [] };
+	}
+
+	const sortedNodeNames = [...nodeNames].toSorted(
+		(a, b) => stageRank(a) - stageRank(b),
+	);
+	const nodeIndex = new Map(
+		sortedNodeNames.map((name, index) => [name, index]),
+	);
+
+	const links: SankeyLink[] = [...edgeWeights.entries()].map(
+		([edgeKey, value]) => {
+			const [sourceName, targetName] = edgeKey.split('->') as [
+				SankeyStage,
+				SankeyStage,
+			];
+			return {
+				source: nodeIndex.get(sourceName) ?? 0,
+				target: nodeIndex.get(targetName) ?? 0,
+				value,
+			};
+		},
+	);
+
+	return {
+		nodes: sortedNodeNames.map((name) => ({ name })),
+		links,
+	};
+};

--- a/src/app/dashboard/_data/application-process-sankey.ts
+++ b/src/app/dashboard/_data/application-process-sankey.ts
@@ -4,10 +4,10 @@ type SankeyStage =
 	| 'Apply'
 	| 'OA'
 	| `Interview #${number}`
+	| 'Ongoing'
 	| 'Offer'
 	| 'Rejected'
 	| 'Ghosted';
-const TERMINAL_OUTCOMES = new Set(['Offer', 'Rejected', 'Ghosted']);
 
 export type SankeyNode = { name: SankeyStage };
 export type SankeyLink = { source: number; target: number; value: number };
@@ -23,6 +23,7 @@ const stageRank = (stage: SankeyStage): number => {
 	if (stage === 'Offer') return 100;
 	if (stage === 'Ghosted') return 101;
 	if (stage === 'Rejected') return 102;
+	if (stage === 'Ongoing') return 103;
 	return Number.MAX_SAFE_INTEGER;
 };
 
@@ -53,6 +54,8 @@ const buildApplicationPath = (
 		stages[stages.length - 1] !== finalStatus
 	) {
 		stages.push(finalStatus);
+	} else if (finalStatus === 'Ongoing' && stages[stages.length - 1] !== 'Ongoing') {
+		stages.push('Ongoing');
 	}
 
 	return stages;
@@ -72,9 +75,6 @@ export const getApplicationProcessSankeyData = async (
 	const edgeWeights = new Map<string, number>();
 
 	for (const application of applications) {
-		if (!TERMINAL_OUTCOMES.has(application.status)) {
-			continue;
-		}
 		const interviews = application.interviews.map((interview) =>
 			String(interview.type),
 		);

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -4,6 +4,8 @@ import { Card, CardContent, CardHeader, CardTitle } from '~/components/ui/card';
 import { APPLICATION_CATEGORY_ICONS, ApplicationCategory } from '~/constants';
 import { getUser } from '~/utils/get-user';
 
+import { ApplicationProcessSankeyChart } from './_components/application-process-sankey-chart';
+import { getApplicationProcessSankeyData } from './_data/application-process-sankey';
 import { getCategorizedApplications } from './_data/applications';
 
 const DashboardPage = async () => {
@@ -12,6 +14,7 @@ const DashboardPage = async () => {
 
 	// TODO: Use database count query instead of querying all the applications
 	const categorizedApplications = await getCategorizedApplications(user.id);
+	const sankeyData = await getApplicationProcessSankeyData(user.id);
 	const categorizedApplicationsCounts = Object.entries(
 		categorizedApplications,
 	).map(([category, applications]) => {
@@ -53,14 +56,14 @@ const DashboardPage = async () => {
 			</div>
 			<Card className="col-span-4">
 				<CardHeader>
-					<CardTitle>Application Status</CardTitle>
+					<CardTitle>Application Process Flow</CardTitle>
 				</CardHeader>
 				<CardContent>
 					<div className="h-96 w-full">
-						{/* TODO: Add sankey diagram */}
-						<div className="flex h-full items-center justify-center text-muted-foreground">
-							A sankey diagram will be displayed here
-						</div>
+						<ApplicationProcessSankeyChart
+							nodes={sankeyData.nodes}
+							links={sankeyData.links}
+						/>
 					</div>
 				</CardContent>
 			</Card>

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import * as React from 'react';
+import { ResponsiveContainer } from 'recharts';
+
+import { cn } from '~/utils/ui';
+
+export type ChartConfig = Record<
+	string,
+	{
+		label?: string;
+		color?: string;
+	}
+>;
+
+type ChartContainerProps = React.ComponentProps<'div'> & {
+	config: ChartConfig;
+	children: React.ComponentProps<
+		typeof import('recharts').ResponsiveContainer
+	>['children'];
+};
+
+export function ChartContainer({
+	id,
+	className,
+	children,
+	config,
+	...props
+}: ChartContainerProps) {
+	const uniqueId = React.useId().replace(/:/g, '');
+	const chartId = `chart-${id ?? uniqueId}`;
+
+	const style = React.useMemo(() => {
+		return Object.entries(config).reduce<Record<string, string>>((acc, [key, item]) => {
+			if (!item.color) return acc;
+			acc[`--color-${key}`] = item.color;
+			return acc;
+		}, {});
+	}, [config]);
+
+	return (
+		<div
+			data-chart={chartId}
+			className={cn(
+				'flex h-full w-full min-h-0 justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-tooltip-cursor]:stroke-border [&_.recharts-layer]:outline-none',
+				className,
+			)}
+			style={style}
+			{...props}
+		>
+			<ResponsiveContainer width="100%" height="100%">
+				{children}
+			</ResponsiveContainer>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary
- add dashboard Sankey chart using shadcn + Recharts
- normalize stages to 
- show always-visible node labels with counts
- ensure rightmost nodes are terminal outcomes only

## Validation
- pnpm lint (existing warnings only)
- pnpm build
- verified with Chrome MCP on 